### PR TITLE
Add Coffeescript Support

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+.DS_Store
+npm-debug.log
+node_modules

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-.DS_Store
-npm-debug.log
-node_modules

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
-# Plain to Jasmine Atom Package #
+Plain to Jasmine Atom Package
+=============================
 
 **Wraps Jasmine syntax around plain text specifications**
 
-_A package inspired by Chris Wheatley [Jasmine Scaffold](https://github.com/swirlycheetah/jasmine-scaffold-sublime-text)_
+*A package inspired by Chris Wheatley [Jasmine Scaffold](https://github.com/swirlycheetah/jasmine-scaffold-sublime-text)*
 
-This package helps to write Jasmine test by writing your specifications in
-plain human language. Once you have your specifications written, activate the
-package and it will insert all the Jasmine syntax.
+This package helps to write Jasmine test by writing your specifications in plain human language. Once you have your specifications written, activate the package and it will insert all the Jasmine syntax.
 
 ![plain-2-jasmine demo](https://raw.githubusercontent.com/jseto/plain-2-jasmine/master/plain-2-jasmine-demo.gif)
 
-### Install ###
+### Install
 
 Use the Atom package manager, which can be found in the Settings view or run
 
@@ -20,11 +19,9 @@ apm install plain-2-jasmine
 
 from the command line.
 
-### Write your specifications ###
+### Write your specifications
 
-Just write your specifications in an indented manner in plain English or any
-other human language.
-
+Just write your specifications in an indented manner in plain English or any other human language.
 
 ```
 My awesome package
@@ -36,20 +33,18 @@ My awesome package
         should insert Jasmine syntax in selected text
 ```
 
-### Activate the package ###
+### Activate the package
 
-Select the text containing your specifications and use any of the following
-methods to activate the package:
+Select the text containing your specifications and use any of the following methods to activate the package:
 
-- Chose `Plain to Jasmine` option under the Package main menu
-- Right click on the selected text and chose `Plain to Jasmine` option
-- <kbd>Ctrl</kbd> <kbd>Shift</kbd> + <kbd>J</kbd>
-- Select `Plain 2 Jasmine` from the command palette
+-	Chose `Plain to Jasmine` option under the Package main menu
+-	Right click on the selected text and chose `Plain to Jasmine` option
+-	<kbd>Ctrl</kbd> <kbd>Shift</kbd> + <kbd>J</kbd>
+-	Select `Plain 2 Jasmine` from the command palette
 
-### Fill up your test code ###
+### Fill up your test code
 
-Once the package is executed you will have inserted the Jasmine syntax code with
-your specifications.
+Once the package is executed you will have inserted the Jasmine syntax code with your specifications.
 
 ```js
 describe( 'My awesome package', function() {
@@ -81,19 +76,37 @@ describe( 'My awesome package', function() {
 });
 ```
 
+Or in Coffeescript:
+
+```coffee
+describe 'My awesome package', ->
+
+    describe 'when select Plain to Jasmine from context menu', ->
+
+        it 'should insert Jasmine syntax in selected text', ->
+
+    describe 'when select Plain to Jasmine from package menu', ->
+
+        it 'should insert Jasmine syntax in selected text', ->
+
+    describe 'when ctrl-shift-j pressed', ->
+
+        it 'should insert Jasmine syntax in selected text', ->
+
+```
+
 Enjoy your testings
 
-## Contribute ##
+Contribute
+----------
 
 If you find a bug, please report it by opening a new [issue](https://github.com/jseto/plain-2-jasmine/issues)
 
-Contributions are very appreciated. Just fork the [repo](https://github.com/jseto/plain-2-jasmine)
-and issue a pull request. Opening an issue about the planned contribution is advisable
-so we can discuss about it.
+Contributions are very appreciated. Just fork the [repo](https://github.com/jseto/plain-2-jasmine) and issue a pull request. Opening an issue about the planned contribution is advisable so we can discuss about it.
 
-Contributions should have tests and description about the new or changed
-functionality.
+Contributions should have tests and description about the new or changed functionality.
 
-## License ##
+License
+-------
 
-_Plain to Jasmine_ is distributed under the [MIT license](http://opensource.org/licenses/MIT)
+*Plain to Jasmine* is distributed under the [MIT license](http://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ describe( 'My awesome package', function() {
 });
 ```
 
-Or in Coffeescript:
+CoffeeScript is supported as well:
 
 ```coffee
 describe 'My awesome package', ->
@@ -92,7 +92,6 @@ describe 'My awesome package', ->
     describe 'when ctrl-shift-j pressed', ->
 
         it 'should insert Jasmine syntax in selected text', ->
-
 ```
 
 Enjoy your testings

--- a/lib/insert-jasmine-coffee-syntax.js
+++ b/lib/insert-jasmine-coffee-syntax.js
@@ -1,0 +1,62 @@
+'use strict';
+
+module.exports = function( str ){
+  var lines = purgueEmptyLines( str.split('\n') );
+  var tabs = retrieveTabsForEachLine( lines );
+
+  return insertJasmine( lines, tabs );
+
+  function purgueEmptyLines( lines ) {
+    var result = [];
+    for( var i in lines ){
+      if ( lines[i].trim().length ){
+        result.push( lines[i] );
+      }
+    }
+    return result;
+  }
+
+  function retrieveTabsForEachLine( lines ) {
+    var tabs=[];
+    for ( var i=0; i<lines.length; ++i ){
+      tabs[i] = lines[i].replace(/^(\s*).*$/, '$1').length;
+    }
+    return tabs;
+  }
+
+  function insertDescribe( str, pos ){
+    var describeText = 'describe \'';
+
+    return [ str.slice( 0, pos ), describeText, str.trimRight().slice( pos ) ].join('');
+  }
+
+  function insertIt( str, pos ){
+    var itText = 'it \'';
+
+    return [ str.slice( 0, pos ), itText, str.trimRight().slice( pos ) ].join('');
+  }
+
+  function functionStr(){
+    return '\', ->';
+  }
+
+  function insertJasmine( lines, tabs ){
+    var result = [];
+    var pendingClose = [];
+
+    for ( var i=0; i<lines.length; ++i ){
+      if ( i===0 ){
+        result.push( insertDescribe( lines[i], tabs[i] ) + functionStr() );
+      }
+      else {
+        if ( ( i >= lines.length - 1 ) || tabs[ i+1 ] <= tabs[i] ) {
+          result.push( insertIt( lines[i], tabs[i] ) + functionStr() );
+        }
+        else {
+          result.push( insertDescribe( lines[i], tabs[i] ) + functionStr() );
+        }
+      }
+    }
+    return result;
+  }
+};

--- a/lib/plain-2-jasmine.js
+++ b/lib/plain-2-jasmine.js
@@ -4,34 +4,54 @@ var CompositeDisposable, Plain2Jasmine;
 
 CompositeDisposable = require('atom').CompositeDisposable;
 var insertJasmineSyntax = require('./insert-jasmine-syntax.js');
+var insertJasmineCoffeeSyntax = require('./insert-jasmine-coffee-syntax.js');
 
 module.exports = Plain2Jasmine = {
-    modalPanel: null,
-    subscriptions: null,
+  modalPanel: null,
+  subscriptions: null,
 
-    activate: function(state) {
-        var _this = this;
-        this.subscriptions = new CompositeDisposable();
-        return this.subscriptions.add( atom.commands.add( 'atom-workspace', {
-                                            'plain-2-jasmine:toggle': function() {
-                                                return _this.toggle();
-                                            }
-                                        }));
-    },
+  activate: function(state) {
+    var _this = this;
+    this.subscriptions = new CompositeDisposable();
+    return this.subscriptions.add( atom.commands.add( 'atom-workspace', {
+      'plain-2-jasmine:toggle': function() {
+        return _this.toggle();
+      }
+    }));
+  },
 
-    deactivate: function() {
-        return this.subscriptions.dispose();
-    },
+  deactivate: function() {
+    return this.subscriptions.dispose();
+  },
 
-    serialize: function() {},
+  serialize: function() {},
 
-    toggle: function() {
-        console.log('Plain2Jasmine was toggled!--------------');
+  getGrammar: function (currentTextEditor){
+    if (currentTextEditor && currentTextEditor.getGrammar())
+      return currentTextEditor.getGrammar().name;
+    else
+      return null;
+  },
 
-        var editor = atom.workspace.getActivePaneItem();
-        var specifications = editor.getSelectedText();
-        var result = insertJasmineSyntax( specifications );
+  toggle: function() {
+    var editor = atom.workspace.getActivePaneItem();
+    var specifications = editor.getSelectedText();
 
-        return editor.insertText( result.join('\n\n') );
+    var result = null;
+
+    // If not sure, assume Javascript by default.
+    var grammar = this.getGrammar(atom.workspace.getActiveTextEditor()) || 'Javascript';
+
+    // using switch, in case more language scopes are added
+    switch (grammar){
+      case "CoffeeScript":
+        result = insertJasmineCoffeeSyntax( specifications );
+        break;
+      default:
+        result = insertJasmineSyntax( specifications );
+        break;
     }
+
+    return editor.insertText( result.join('\n\n') );
+  }
 };

--- a/lib/plain-2-jasmine.js
+++ b/lib/plain-2-jasmine.js
@@ -11,14 +11,14 @@ module.exports = Plain2Jasmine = {
   subscriptions: null,
 
   activate: function(state) {
-    var _this = this;
-    this.subscriptions = new CompositeDisposable();
-    return this.subscriptions.add( atom.commands.add( 'atom-workspace', {
-      'plain-2-jasmine:toggle': function() {
-        return _this.toggle();
-      }
-    }));
-  },
+        var _this = this;
+        this.subscriptions = new CompositeDisposable();
+        return this.subscriptions.add( atom.commands.add( 'atom-workspace', {
+                                            'plain-2-jasmine:toggle': function() {
+                                                return _this.toggle();
+                                            }
+                                        }));
+    },
 
   deactivate: function() {
     return this.subscriptions.dispose();

--- a/package.json
+++ b/package.json
@@ -6,10 +6,37 @@
   "activationCommands": {
     "atom-workspace": "plain-2-jasmine:toggle"
   },
-  "repository": "https://github.com/jseto/plain-2-jasmine",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jseto/plain-2-jasmine"
+  },
   "license": "MIT",
   "engines": {
     "atom": ">=0.174.0 <2.0.0"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "readme": "# Plain to Jasmine Atom Package #\n\n**Wraps Jasmine syntax around plain text specifications**\n\n_A package inspired by Chris Wheatley [Jasmine Scaffold](https://github.com/swirlycheetah/jasmine-scaffold-sublime-text)_\n\nThis package helps to write Jasmine test by writing your specifications in\nplain human language. Once you have your specifications written, activate the\npackage and it will insert all the Jasmine syntax.\n\n![plain-2-jasmine demo](https://raw.githubusercontent.com/jseto/plain-2-jasmine/master/plain-2-jasmine-demo.gif)\n\n### Install ###\n\nUse the Atom package manager, which can be found in the Settings view or run\n\n```\napm install plain-2-jasmine\n```\n\nfrom the command line.\n\n### Write your specifications ###\n\nJust write your specifications in an indented manner in plain English or any\nother human language.\n\n\n```\nMy awesome package\n    when select Plain to Jasmine from context menu\n        should insert Jasmine syntax in selected text\n    when select Plain to Jasmine from package menu\n        should insert Jasmine syntax in selected text\n    when ctrl-shift-j pressed\n        should insert Jasmine syntax in selected text\n```\n\n### Activate the package ###\n\nSelect the text containing your specifications and use any of the following\nmethods to activate the package:\n\n- Chose `Plain to Jasmine` option under the Package main menu\n- Right click on the selected text and chose `Plain to Jasmine` option\n- <kbd>Ctrl</kbd> <kbd>Shift</kbd> + <kbd>J</kbd>\n- Select `Plain 2 Jasmine` from the command palette\n\n### Fill up your test code ###\n\nOnce the package is executed you will have inserted the Jasmine syntax code with\nyour specifications.\n\n```js\ndescribe( 'My awesome package', function() {\n\n    describe( 'when select Plain to Jasmine from context menu', function() {\n\n        it( 'should insert Jasmine syntax in selected text', function() {\n\n        });\n\n    });\n\n    describe( 'when select Plain to Jasmine from package menu', function() {\n\n        it( 'should insert Jasmine syntax in selected text', function() {\n\n        });\n\n    });\n\n    describe( 'when ctrl-shift-j pressed', function() {\n\n        it( 'should insert Jasmine syntax in selected text', function() {\n\n        });\n\n    });\n\n});\n```\n\nEnjoy your testings\n\n## Contribute ##\n\nIf you find a bug, please report it by opening a new [issue](https://github.com/jseto/plain-2-jasmine/issues)\n\nContributions are very appreciated. Just fork the [repo](https://github.com/jseto/plain-2-jasmine)\nand issue a pull request. Opening an issue about the planned contribution is advisable\nso we can discuss about it.\n\nContributions should have tests and description about the new or changed\nfunctionality.\n\n## License ##\n\n_Plain to Jasmine_ is distributed under the [MIT license](http://opensource.org/licenses/MIT)\n",
+  "readmeFilename": "README.md",
+  "bugs": {
+    "url": "https://github.com/jseto/plain-2-jasmine/issues"
+  },
+  "homepage": "https://github.com/jseto/plain-2-jasmine",
+  "_id": "plain-2-jasmine@0.1.2",
+  "_shasum": "3eb8547e7dbefe1d5a2bcae44e2ce9ca47f3755c",
+  "_resolved": "file:..\\d-115617-17900-13v4hlw\\package.tgz",
+  "_from": "..\\d-115617-17900-13v4hlw\\package.tgz",
+  "_atomModuleCache": {
+    "version": 1,
+    "dependencies": [],
+    "extensions": {
+      ".js": [
+        "lib\\insert-jasmine-syntax.js",
+        "lib\\plain-2-jasmine.js"
+      ],
+      ".json": [
+        "package.json"
+      ]
+    },
+    "folders": []
+  }
 }

--- a/spec/insert-jasmine-coffee-syntax-spec.js
+++ b/spec/insert-jasmine-coffee-syntax-spec.js
@@ -1,0 +1,157 @@
+'use strict';
+
+var insertJasmineCoffeeSyntax = require('../lib/insert-jasmine-coffee-syntax.js');
+
+describe( 'insertJasmineCoffeeSyntax module', function(){
+    it( 'should insert in unindent it after same level describe block pattern', function(){
+        var buffer = [
+            'the first describe',
+            '    a description again',
+            '        another it',
+            '    another it',
+            '    a description',
+            '        an it'
+        ].join('\n');
+
+        var expectation = [
+          'describe \'the first describe\', ->',
+          '    describe \'a description again\', ->',
+          '        it \'another it\', ->',
+          '    it \'another it\', ->',
+          '    describe \'a description\', ->',
+          '        it \'an it\', ->'
+        ].join('\n');
+
+        expect( insertJasmineCoffeeSyntax( buffer ).join('\n') ).toBe( expectation );
+    });
+
+    it( 'should insert in unindent pattern', function(){
+        var buffer = [
+            'the first describe',
+            '    a description again',
+            '        another it',
+            '    a description',
+            '        an it',
+            'other main description',
+            '    a sub-description',
+            '        an it here'
+        ].join('\n');
+
+        var expectation = [
+          'describe \'the first describe\', ->',
+          '    describe \'a description again\', ->',
+          '        it \'another it\', ->',
+          '    describe \'a description\', ->',
+          '        it \'an it\', ->',
+          'describe \'other main description\', ->',
+          '    describe \'a sub-description\', ->',
+          '        it \'an it here\', ->'
+        ].join('\n');
+
+        expect( insertJasmineCoffeeSyntax( buffer ).join('\n') ).toBe( expectation );
+    });
+
+    it( 'should strip out trailing whitespace', function(){
+        var buffer = [
+            'a trivial buffer',
+            '\tshould return proper jasmine'
+        ].join('\n');
+
+        var expectation = [
+            'describe \'a trivial buffer\', ->',
+            '\tit \'should return proper jasmine\', ->'
+        ].join('\n');
+
+        expect( insertJasmineCoffeeSyntax( buffer ).join('\n') ).toBe( expectation );
+        buffer += '   ';
+        expect( insertJasmineCoffeeSyntax( buffer ).join('\n') ).toBe( expectation );
+    });
+
+    it( 'should insert jasmine syntax in a trivial buffer with hard-tabs', function(){
+        var buffer = [
+            'a trivial buffer',
+            '\tshould return proper jasmine'
+        ].join('\n');
+
+        var expectation = [
+          'describe \'a trivial buffer\', ->',
+          '\tit \'should return proper jasmine\', ->'
+        ].join('\n');
+
+        expect( insertJasmineCoffeeSyntax( buffer ).join('\n') ).toBe( expectation );
+    });
+
+    it( 'should insert jasmine syntax in a trivial buffer with soft-tabs', function(){
+        var buffer = [
+            'a trivial buffer',
+            '  should return proper jasmine'
+        ].join('\n');
+
+        var expectation = [
+          'describe \'a trivial buffer\', ->',
+          '  it \'should return proper jasmine\', ->'
+        ].join('\n');
+
+        expect( insertJasmineCoffeeSyntax( buffer ).join('\n') ).toBe( expectation );
+    });
+
+    it( 'should insert in describe-decribe-it pattern', function(){
+        var buffer = [
+            'the first describe',
+            '   should be followed by a second describe',
+            '     and an it function'
+        ].join('\n');
+
+        var expectation = [
+          'describe \'the first describe\', ->',
+          '   describe \'should be followed by a second describe\', ->',
+          '     it \'and an it function\', ->'
+        ].join('\n');
+
+        expect( insertJasmineCoffeeSyntax( buffer ).join('\n') ).toBe( expectation );
+    });
+
+    it( 'should insert in describe-it-decribe-it pattern', function(){
+        var buffer = [
+            'the first describe',
+            '   should be followed by it',
+            '   and an a description',
+            '     and other it'
+        ].join('\n');
+
+        var expectation = [
+          'describe \'the first describe\', ->',
+          '   it \'should be followed by it\', ->',
+          '   describe \'and an a description\', ->',
+          '     it \'and other it\', ->'
+        ].join('\n');
+
+        expect( insertJasmineCoffeeSyntax( buffer ).join('\n') ).toBe( expectation );
+    });
+
+    it( 'should insert in describe-it-it-decribe-it-describe-it-it pattern', function(){
+        var buffer = [
+            'the first describe',
+            '   should be followed by it',
+            '   should be followed by another it',
+            '   and an a description',
+            '       and other it',
+            '       a description again',
+            '           another it',
+            '           and one more it'
+        ].join('\n');
+
+        var expectation = [
+          'describe \'the first describe\', ->',
+          '   it \'should be followed by it\', ->',
+          '   it \'should be followed by another it\', ->',
+          '   describe \'and an a description\', ->',
+          '       it \'and other it\', ->',
+          '       describe \'a description again\', ->',
+          '           it \'another it\', ->',
+          '           it \'and one more it\', ->'
+        ].join('\n');
+
+        expect( insertJasmineCoffeeSyntax( buffer ).join('\n') ).toBe( expectation );
+    });
+});


### PR DESCRIPTION
Hi dude,

Thought I'd do this part if you're interested.
Addresses https://github.com/jseto/plain-2-jasmine/issues/2

![ExampleGif](http://i.imgur.com/mjIHyUS.gif)

Essentially, if the selected language scope is CoffeeScript, it will do your thing coffee-style.
If it's anything else, it will default back to Javascript.

Hope you like it.
